### PR TITLE
base-alpine: use `curl` for all http/https needs

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -4,15 +4,15 @@ MAINTAINER Bitnami <containers@bitnami.com>
 ENV BITNAMI_PREFIX=/opt/bitnami \
     S6_OVERLAY_VERSION=1.14.0.4
 
-RUN apk add --update wget libstdc++ bash ca-certificates sudo curl coreutils && \
-    wget "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
-    wget "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-bin-2.21-r2.apk" && \
-    wget "http://nl.alpinelinux.org/alpine/edge/testing/x86_64/shadow-4.2.1-r3.apk" && \
+RUN apk add --update libstdc++ bash ca-certificates sudo curl coreutils && \
+    curl -LO "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
+    curl -LO "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-bin-2.21-r2.apk" && \
+    curl -LO "http://nl.alpinelinux.org/alpine/edge/testing/x86_64/shadow-4.2.1-r3.apk" && \
     apk add --allow-untrusted glibc-2.21-r2.apk glibc-bin-2.21-r2.apk shadow-4.2.1-r3.apk && \
     /usr/glibc/usr/bin/ldconfig /lib /usr/glibc/usr/lib && \
-    wget https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz && \
+    curl -LO https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz && \
     tar -zxf s6-overlay-amd64.tar.gz -C / && \
-    wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/1.4/gosu-amd64" && \
+    curl -o /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/1.4/gosu-amd64" && \
     chmod +x /usr/bin/gosu && \
     addgroup bitnami && \
     adduser -h /home/bitnami -s /bin/bash -D -G bitnami -g "" bitnami && \

--- a/alpine/rootfs/opt/bitnami/install.sh
+++ b/alpine/rootfs/opt/bitnami/install.sh
@@ -11,9 +11,9 @@ else
   url=https://downloads.bitnami.com/files/download/containers/$BITNAMI_APP_NAME/$BITNAMI_APP_FILENAME
   echo $url
   if [ $SHOW_PROGRESS ]; then
-    wget $url -O /tmp/installer.run
+    curl -SL --progress-bar $url -o /tmp/installer.run
   else
-    wget -q $url -O /tmp/installer.run
+    curl -SLs $url -o /tmp/installer.run
   fi
 fi
 


### PR DESCRIPTION
Removes wget package and uses curl only