### PR TITLE
extend entrypoint.sh script for use in images that don't use s6-overlay

### DIFF
--- a/alpine/rootfs/entrypoint.sh
+++ b/alpine/rootfs/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# populate EXTRA_OPTIONS for the main service daemon
 if [ -n "$BITNAMI_APP_DAEMON" ]; then
+  # populate EXTRA_OPTIONS for the main service daemon
   if [ "${1:0:1}" = '-' ]; then
     export EXTRA_OPTIONS="$@"
     set --
@@ -18,16 +18,26 @@ if [ -n "$BITNAMI_APP_DAEMON" ]; then
     done
   fi
 
-  # default is the first listed daemon
+  # default is the first daemon listed in BITNAMI_APP_DAEMON
   export BITNAMI_APP_DAEMON=$(awk -F '|' '{print $1}' <<< $BITNAMI_APP_DAEMON)
-fi
 
-# do not start services if user specifies a command
-if [ -n "${1}" ]; then
-  for service in $(ls /etc/services.d/)
-  do
-    touch /etc/services.d/$service/down
-  done
-fi
+  # do not start services if user specifies a command
+  if [ -n "${1}" ]; then
+    for service in $(ls /etc/services.d/)
+    do
+      touch /etc/services.d/$service/down
+    done
+  fi
 
-exec /init "$@"
+  exec /init "$@"
+else
+  source $BITNAMI_PREFIX/bitnami-utils.sh
+
+  if [ -z "$DISABLE_UPDATE_CHECK" ]; then
+    check_for_updates &
+  fi
+
+  print_welcome_page
+
+  exec "$@"
+fi

--- a/ubuntu/rootfs/entrypoint.sh
+++ b/ubuntu/rootfs/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# populate EXTRA_OPTIONS for the main service daemon
 if [ -n "$BITNAMI_APP_DAEMON" ]; then
+  # populate EXTRA_OPTIONS for the main service daemon
   if [ "${1:0:1}" = '-' ]; then
     export EXTRA_OPTIONS="$@"
     set --
@@ -18,16 +18,26 @@ if [ -n "$BITNAMI_APP_DAEMON" ]; then
     done
   fi
 
-  # default is the first listed daemon
+  # default is the first daemon listed in BITNAMI_APP_DAEMON
   export BITNAMI_APP_DAEMON=$(awk -F '|' '{print $1}' <<< $BITNAMI_APP_DAEMON)
-fi
 
-# do not start services if user specifies a command
-if [ -n "${1}" ]; then
-  for service in $(ls /etc/services.d/)
-  do
-    touch /etc/services.d/$service/down
-  done
-fi
+  # do not start services if user specifies a command
+  if [ -n "${1}" ]; then
+    for service in $(ls /etc/services.d/)
+    do
+      touch /etc/services.d/$service/down
+    done
+  fi
 
-exec /init "$@"
+  exec /init "$@"
+else
+  source $BITNAMI_PREFIX/bitnami-utils.sh
+
+  if [ -z "$DISABLE_UPDATE_CHECK" ]; then
+    check_for_updates &
+  fi
+
+  print_welcome_page
+
+  exec "$@"
+fi


### PR DESCRIPTION
Images that rely on the s6-overlay init system define a variable named
`BITNAMI_APP_DAEMON`. We use this variable to decide if an image relies
n s6.

closes #30