### PR TITLE
Take the origin of the update check from the environment

### DIFF
--- a/alpine/rootfs/opt/bitnami/bitnami-utils.sh
+++ b/alpine/rootfs/opt/bitnami/bitnami-utils.sh
@@ -89,11 +89,11 @@ print_bitnami_help_page() {
 # Checks for any updates for this Docker image
 check_for_updates() {
   UPDATE_SERVER="https://container.checkforupdates.com"
-  ORIGIN="DHR"
+  ORIGIN=${BITNAMI_CONTAINER_ORIGIN:-DHR}
 
   RESPONSE=$(curl -s --connect-timeout 20 \
     --cacert $BITNAMI_PREFIX/updates-ca-cert.pem \
-    "$UPDATE_SERVER/api/v1?image=$BITNAMI_APP_NAME&version=$BITNAMI_APP_VERSION&origin=DHR" \
+    "$UPDATE_SERVER/api/v1?image=$BITNAMI_APP_NAME&version=$BITNAMI_APP_VERSION&origin=$ORIGIN" \
     -w "|%{http_code}")
 
   VERSION=$(echo $RESPONSE | cut -d '|' -f 1)

--- a/ubuntu/rootfs/opt/bitnami/bitnami-utils.sh
+++ b/ubuntu/rootfs/opt/bitnami/bitnami-utils.sh
@@ -89,11 +89,11 @@ print_bitnami_help_page() {
 # Checks for any updates for this Docker image
 check_for_updates() {
   UPDATE_SERVER="https://container.checkforupdates.com"
-  ORIGIN="DHR"
+  ORIGIN=${BITNAMI_CONTAINER_ORIGIN:-DHR}
 
   RESPONSE=$(curl -s --connect-timeout 20 \
     --cacert $BITNAMI_PREFIX/updates-ca-cert.pem \
-    "$UPDATE_SERVER/api/v1?image=$BITNAMI_APP_NAME&version=$BITNAMI_APP_VERSION&origin=DHR" \
+    "$UPDATE_SERVER/api/v1?image=$BITNAMI_APP_NAME&version=$BITNAMI_APP_VERSION&origin=$ORIGIN" \
     -w "|%{http_code}")
 
   VERSION=$(echo $RESPONSE | cut -d '|' -f 1)


### PR DESCRIPTION
This change is needed for supporting update checking for containers published in the Google Container Registry