### PR TITLE
Switch to track official ubuntu image

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-debootstrap:14.04
+FROM ubuntu:trusty-20160217
 MAINTAINER Bitnami <containers@bitnami.com>
 
 ENV BITNAMI_APP_NAME=base \


### PR DESCRIPTION
The trusty-20160217 release has a patch for the stack-based buffer overflow vulnerability in glibc
http://people.canonical.com/~ubuntu-security/cve/2015/CVE-2015-7547.html